### PR TITLE
Add documentation for getsubopt function in memcached

### DIFF
--- a/packages/memcached/getsubopt.h
+++ b/packages/memcached/getsubopt.h
@@ -1,4 +1,11 @@
 #ifndef _getsubopt_h
 #define _getsubopt_h
+/**
+ * Parses option suboptions from a string.
+ * @param optionp Pointer to the string to parse.
+ * @param tokens Array of valid suboption tokens.
+ * @param valuep Pointer to store the value part.
+ * @return Index of the matched token or -1 if no match.
+ */
 int getsubopt (char **optionp, char *const *tokens, char **valuep);
 #endif


### PR DESCRIPTION
## Problem Background
The public function `getsubopt` declared in `packages/memcached/getsubopt.h` lacks documentation comments, which decreases code readability and maintainability. This makes it harder for developers to understand the function's purpose, parameters, and return values without inspecting the implementation.

## Modification
Added a docstring to the `getsubopt` function in the header file, providing clear descriptions for its parameters and return value. This change improves code documentation while preserving all existing functionality and API compatibility.

## Verification
- Review the added comments for accuracy and adherence to C documentation conventions.
- Ensure the header file still compiles correctly in the build system by running relevant tests or compilation checks.
- Confirm that no functional behavior is altered, as only documentation was added.